### PR TITLE
Add tests for teacher services and routes

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,9 @@ fastapi
 uvicorn[standard]
 SQLAlchemy
 pydantic
+
+# Testing
+pytest
+requests
+httpx
+email-validator

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.main import app
+from app.db import Base, get_db
+from app.models import Teacher
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(scope="function")
+def client(db_session: Session) -> Generator[TestClient, None, None]:
+    """Return a TestClient using the in-memory database session."""
+
+    def override_get_db() -> Generator[Session, None, None]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    del app.dependency_overrides[get_db]
+
+
+@pytest.fixture(scope="function")
+def test_teacher(db_session: Session) -> Teacher:
+    """Create a sample teacher for use in tests."""
+
+    teacher = Teacher(email="test@example.com", name="Test Teacher")
+    db_session.add(teacher)
+    db_session.commit()
+    db_session.refresh(teacher)
+    return teacher
+

--- a/backend/tests/routers/test_teacher_router.py
+++ b/backend/tests/routers/test_teacher_router.py
@@ -1,0 +1,126 @@
+from fastapi.testclient import TestClient
+from app.models import Teacher
+
+
+def test_create_student_unauthenticated(client: TestClient) -> None:
+    """Creating a student without authentication should fail."""
+
+    response = client.post("/api/teacher/students", json={"name": "Test Student"})
+
+    assert response.status_code == 422
+
+
+def test_create_student_authenticated(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """A teacher can create a student when authenticated."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    student_payload = {"name": "Jane Doe", "email": "jane.doe@example.com"}
+
+    response = client.post(
+        "/api/teacher/students", headers=headers, json=student_payload
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Jane Doe"
+    assert data["id"] is not None
+
+
+def test_get_students_authenticated(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """Authenticated teacher should retrieve their students."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    client.post("/api/teacher/students", headers=headers, json={"name": "Student A"})
+
+    response = client.get("/api/teacher/students", headers=headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == "Student A"
+
+
+def test_create_assignment_authenticated(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """Authenticated teacher can create an assignment."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    payload = {"title": "My Assignment"}
+
+    response = client.post("/api/teacher/assignments", headers=headers, json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "My Assignment"
+    assert data["assignment_id"] is not None
+    assert data["status"] == "draft"
+    assert data["canvas_json"] == []
+
+
+def test_create_assignment_missing_header(client: TestClient) -> None:
+    """Missing authentication header should result in validation error."""
+
+    response = client.post("/api/teacher/assignments", json={"title": "Test"})
+
+    assert response.status_code == 422
+
+
+def test_create_material_authenticated(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """Authenticated teacher can create material."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    payload = {
+        "title": "Chapter 1",
+        "content": "Content for chapter 1"
+    }
+
+    response = client.post("/api/teacher/materials", headers=headers, json=payload)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Chapter 1"
+    assert data["content"] == "Content for chapter 1"
+    assert data["id"] is not None
+
+
+def test_create_material_invalid_payload(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """Invalid payload should trigger validation error."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    payload = {"title": "Incomplete"}  # Missing 'content'
+
+    response = client.post("/api/teacher/materials", headers=headers, json=payload)
+
+    assert response.status_code == 422
+
+
+def test_get_materials_authenticated(
+    client: TestClient, test_teacher: Teacher
+) -> None:
+    """Authenticated teacher should retrieve materials."""
+
+    headers = {"X-Teacher-ID": test_teacher.id}
+    client.post(
+        "/api/teacher/materials",
+        headers=headers,
+        json={"title": "Note", "content": "Some content here"},
+    )
+
+    response = client.get("/api/teacher/materials", headers=headers)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["title"] == "Note"
+

--- a/backend/tests/services/test_teacher_service.py
+++ b/backend/tests/services/test_teacher_service.py
@@ -1,0 +1,88 @@
+from sqlalchemy.orm import Session
+
+from app.services import teacher_service
+from app.schemas import StudentCreate, MaterialCreate
+from app.models import Teacher
+
+
+def test_create_student_for_teacher(db_session: Session, test_teacher: Teacher) -> None:
+    """Ensure a student can be created for a teacher."""
+
+    student_data = StudentCreate(name="John Doe", email="john.doe@example.com")
+
+    student = teacher_service.create_student_for_teacher(
+        db=db_session, teacher_id=test_teacher.id, student_data=student_data
+    )
+
+    assert student is not None
+    assert student.name == "John Doe"
+    assert student.email == "john.doe@example.com"
+    assert student.teacher_id == test_teacher.id
+    assert student.id is not None
+
+
+def test_get_students_for_teacher(db_session: Session, test_teacher: Teacher) -> None:
+    """Retrieve all students for a given teacher."""
+
+    teacher_service.create_student_for_teacher(
+        db=db_session,
+        teacher_id=test_teacher.id,
+        student_data=StudentCreate(name="Student 1"),
+    )
+    teacher_service.create_student_for_teacher(
+        db=db_session,
+        teacher_id=test_teacher.id,
+        student_data=StudentCreate(name="Student 2"),
+    )
+
+    students = teacher_service.get_students_for_teacher(
+        db=db_session, teacher_id=test_teacher.id
+    )
+
+    assert len(students) == 2
+    assert students[0].name == "Student 1"
+
+
+def test_create_material_for_teacher(db_session: Session, test_teacher: Teacher) -> None:
+    """Ensure a material can be created for a teacher."""
+
+    material_data = MaterialCreate(
+        title="Lesson 1", content="This is the content of lesson 1"
+    )
+
+    material = teacher_service.create_material_for_teacher(
+        db=db_session, teacher_id=test_teacher.id, material_data=material_data
+    )
+
+    assert material is not None
+    assert material.title == "Lesson 1"
+    assert material.content == "This is the content of lesson 1"
+    assert material.teacher_id == test_teacher.id
+    assert material.id is not None
+
+
+def test_get_materials_for_teacher(db_session: Session, test_teacher: Teacher) -> None:
+    """Retrieve all materials for a given teacher."""
+
+    teacher_service.create_material_for_teacher(
+        db=db_session,
+        teacher_id=test_teacher.id,
+        material_data=MaterialCreate(
+            title="Material 1", content="Content 1234567890"
+        ),
+    )
+    teacher_service.create_material_for_teacher(
+        db=db_session,
+        teacher_id=test_teacher.id,
+        material_data=MaterialCreate(
+            title="Material 2", content="Another content 123456"
+        ),
+    )
+
+    materials = teacher_service.get_materials_for_teacher(
+        db=db_session, teacher_id=test_teacher.id
+    )
+
+    assert len(materials) == 2
+    assert materials[0].title == "Material 1"
+


### PR DESCRIPTION
## Summary
- add pytest-based infrastructure with in-memory SQLite
- cover teacher services for students and materials
- add integration tests for teacher endpoints

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0949758f0832d88fe9603fcd605fc