### PR TITLE
Add teacher auth, dashboards, and grading workflows

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,3 +1,16 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import schemas
+from ..services import auth_service
+from ..db import get_db
 
 router = APIRouter(prefix="/api/auth", tags=["Auth"])
+
+
+@router.post("/register", response_model=schemas.Teacher, status_code=201)
+def handle_register_teacher(
+    teacher_data: schemas.TeacherCreate, db: Session = Depends(get_db)
+):
+    """Register a new teacher and simulate sending a login link."""
+    return auth_service.register_teacher(db, teacher_data)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -56,6 +56,18 @@ class MaterialDetail(Material):
     content: str
 
 
+# --- Dashboard Schemas ---
+class DashboardStudent(BaseModel):
+    id: str
+    name: str
+    ungraded_submissions: int
+    graded_submissions: int
+
+
+class DashboardResponse(BaseModel):
+    students: List[DashboardStudent]
+
+
 # --- Assignment Schemas ---
 class AssignmentCreateRequest(BaseModel):
     title: str = Field("Новое задание", min_length=1, max_length=100)
@@ -107,6 +119,15 @@ class TeacherSubmissionView(BaseModel):
     ai_feedback: Dict[str, Any] | None = None
     final_score: float | None = None
     final_feedback: str | None = None
+
+
+class FinalGradeRequest(BaseModel):
+    final_score: float = Field(..., ge=0, le=1)
+    final_feedback: str | None = None
+
+
+class StudentDashboardResponse(BaseModel):
+    assignments: List[StudentAssignmentView]
 
 
 # --- AI Schemas ---

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -12,3 +12,16 @@ async def get_current_teacher(x_teacher_id: str = Header(...), db: Session = Dep
     if not teacher:
         raise HTTPException(status_code=403, detail="Invalid Teacher ID")
     return teacher
+
+
+async def get_current_submission(access_token: str, db: Session = Depends(get_db)) -> models.Submission:
+    """Retrieve a submission by its access token."""
+
+    submission = (
+        db.query(models.Submission)
+        .filter(models.Submission.access_token == access_token)
+        .first()
+    )
+    if not submission:
+        raise HTTPException(status_code=404, detail="Invalid access token")
+    return submission

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,29 @@
+"""Service layer for teacher authentication."""
+
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .. import models, schemas
+
+
+def register_teacher(db: Session, teacher_data: schemas.TeacherCreate) -> models.Teacher:
+    """Create a new teacher in the database and simulate sending a magic link."""
+    try:
+        teacher = models.Teacher(**teacher_data.model_dump())
+        db.add(teacher)
+        db.commit()
+        db.refresh(teacher)
+
+        # --- STUB for sending magic link ---
+        # In a real application, you would generate a temporary token,
+        # persist it, and send an email containing the login URL.
+        print("--- AUTH SIMULATION ---")
+        print(f"Teacher registered with ID: {teacher.id}")
+        print("To log in, use this ID in the 'X-Teacher-ID' header.")
+        print("-----------------------")
+
+        return teacher
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="A teacher with this email already exists.") from exc

--- a/backend/app/services/teacher_service.py
+++ b/backend/app/services/teacher_service.py
@@ -1,4 +1,8 @@
+"""Service layer for teacher-related operations."""
+
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
+
 from .. import models, schemas
 
 
@@ -24,3 +28,43 @@ def create_material_for_teacher(db: Session, teacher_id: str, material_data: sch
 
 def get_materials_for_teacher(db: Session, teacher_id: str) -> list[models.Material]:
     return db.query(models.Material).filter(models.Material.teacher_id == teacher_id).all()
+
+
+def get_dashboard_data(db: Session, teacher_id: str) -> list[dict]:
+    """Aggregate dashboard statistics for all students of a teacher."""
+
+    stmt = (
+        db.query(
+            models.Student.id,
+            models.Student.name,
+            func.count(models.Submission.id).label("total_submissions"),
+            func.sum(
+                case(
+                    (models.Submission.status == models.SubmissionStatus.SUBMITTED, 1),
+                    else_=0,
+                )
+            ).label("ungraded_submissions"),
+            func.sum(
+                case(
+                    (models.Submission.status == models.SubmissionStatus.GRADED, 1),
+                    else_=0,
+                )
+            ).label("graded_submissions"),
+        )
+        .outerjoin(models.Submission, models.Student.id == models.Submission.student_id)
+        .filter(models.Student.teacher_id == teacher_id)
+        .group_by(models.Student.id)
+        .order_by(models.Student.name)
+    )
+
+    results = stmt.all()
+    dashboard_data = [
+        {
+            "id": r.id,
+            "name": r.name,
+            "ungraded_submissions": r.ungraded_submissions or 0,
+            "graded_submissions": r.graded_submissions or 0,
+        }
+        for r in results
+    ]
+    return dashboard_data


### PR DESCRIPTION
## Summary
- Implement magic-link style teacher registration
- Aggregate student submission statistics for teacher dashboard
- Allow teachers to finalize grades and students to view all assignments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09a16b694832daff8057f0d648406