### PR TITLE
Add Telegram bot with OpenAI integration

### DIFF
--- a/backend/app/telegram_bot.py
+++ b/backend/app/telegram_bot.py
@@ -1,0 +1,70 @@
+"""Telegram bot powered by aiogram and OpenAI."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Optional
+
+from aiogram import Bot, Dispatcher, F
+from aiogram.filters import CommandStart
+from aiogram.types import Message
+from dotenv import load_dotenv
+from openai import AsyncOpenAI
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+bot_token = os.getenv("TELEGRAM_TOKEN")
+if not bot_token:
+    raise RuntimeError("TELEGRAM_TOKEN is not set")
+
+bot = Bot(token=bot_token)
+dp = Dispatcher()
+
+# Global OpenAI client instance
+openai_client = AsyncOpenAI()
+
+
+async def generate_answer(prompt: str, client: Optional[AsyncOpenAI] = None) -> str:
+    """Generate an AI response using OpenAI's chat completion API.
+
+    Args:
+        prompt: User prompt to send to the LLM.
+        client: Optional custom `AsyncOpenAI` instance for dependency injection.
+
+    Returns:
+        A string with the model's reply.
+    """
+
+    client = client or openai_client
+    response = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+@dp.message(CommandStart())
+async def cmd_start(message: Message) -> None:
+    """Handle the /start command."""
+
+    await message.answer("Привет! Напиши мне вопрос.")
+
+
+@dp.message(F.text)
+async def handle_message(message: Message) -> None:
+    """Handle incoming text messages."""
+
+    reply = await generate_answer(message.text)
+    await message.answer(reply)
+
+
+async def main() -> None:
+    """Run the Telegram bot."""
+
+    await dp.start_polling(bot)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,8 @@ uvicorn[standard]
 SQLAlchemy
 pydantic
 openai==1.93.0
+aiogram==3.15.0
+python-dotenv==1.1.1
 
 # Testing
 pytest

--- a/backend/tests/test_telegram_bot.py
+++ b/backend/tests/test_telegram_bot.py
@@ -1,0 +1,28 @@
+"""Tests for the Telegram bot module."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("TELEGRAM_TOKEN", "123456:ABC")
+os.environ.setdefault("OPENAI_API_KEY", "dummy")
+from app import telegram_bot
+
+
+def test_generate_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """generate_answer should return model output."""
+
+    async def fake_create(*args, **kwargs):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="test"))]
+        )
+
+    monkeypatch.setattr(
+        telegram_bot.openai_client.chat.completions, "create", fake_create
+    )
+
+    result = asyncio.run(telegram_bot.generate_answer("hi"))
+
+    assert result == "test"


### PR DESCRIPTION
## Summary
- add aiogram-based Telegram bot leveraging AsyncOpenAI
- cover bot response generation with unit test
- document dependencies for aiogram and dotenv

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b5b1d814832d9ca7c724787422cd